### PR TITLE
fix syntax errors and split the create a rails app section into a seperate page for docker

### DIFF
--- a/sites/en/installfest/create_a_rails_app.step
+++ b/sites/en/installfest/create_a_rails_app.step
@@ -1,5 +1,8 @@
 tip do
-  message "Ignore this if you installed Docker"
+  message "**WAIT! If you are using Docker, SKIP this page and go to [Create a Rails App with Docker] (create_a_rails_app_with_docker)**"
+end
+
+tip do
   console_with_message "From here on, this guide assumes you have Rails 5.0.x. To check your Rails version, type this in the terminal:", "rails -v"
   fuzzy_result "Rails 5.0{FUZZY}.x{/FUZZY}"
   message "If your computer reports a Rails version less than 5.0, ask a TA help get you back on track."
@@ -20,101 +23,13 @@ step "Change to your new railsbridge directory" do
 end
 
 step "Create a new Rails app" do
-  option_half "Without Docker" do
-    console "rails new test_app"
 
-    message "The command's output is voluminous, and will take some time to complete, with a long pause in the middle, after all the 'create...' statements ending in 'bundle install'.  When it fully completes, it will return you to your home prompt.  Look for the 'Bundle complete!' message just above."
+  console "rails new test_app"
 
-    console "cd test_app"
-    console "rails server"
-  end
+  message "The command's output is voluminous, and will take some time to complete, with a long pause in the middle, after all the 'create...' statements ending in 'bundle install'.  When it fully completes, it will return you to your home prompt.  Look for the 'Bundle complete!' message just above."
 
-  option_half "With Docker" do
-    console "mkdir test_app"
-    console "cd test_app"
-
-    message "In your editor, create a new file called `Gemfile`"
-    message "Copy the following into `Gemfile`:"
-    source_code :ruby, <<-CONTENTS
-      source "https://rubygems.org"
-      gem "rails", "5.2.0"
-    CONTENTS
-    console "touch Gemfile.lock"
-
-    message "In your editor, create a new file called `Dockerfile`:"
-    message "Copy the following into `Dockerfile`:"
-    source_code :text, <<-CONTENTS
-      FROM ruby:2.5.1-slim
-
-      RUN apt-get update -qq && apt-get install -y build-essential libpq-dev git vim nodejs postgresql-client build-essential
-
-      ENV APP_HOME /test_app
-      RUN mkdir -p $APP_HOME
-      WORKDIR $APP_HOME
-      COPY Gemfile* $APP_HOME/
-      RUN bundle install --binstubs
-      COPY . $APP_HOME
-    CONTENTS
-
-    message "In your editor, create a new file called `docker-compose.yml`:"
-    message "Copy the following into `docker-compose.yml`:"
-    source_code :text, <<-CONTENTS
-      version: '3'
-      services:
-        db:
-          image: postgres:10.3
-          volumes:
-            - db_data:/var/lib/postgresql/data
-        web:
-          build: .
-          environment:
-            DB_HOST: db
-          tty: true
-          stdin_open: true
-          volumes:
-            - .:/test_app
-          command: bin/rails s -p 3000 -b '0.0.0.0'
-          ports:
-            - "3000:3000"
-          depends_on:
-            - db
-      volumes:
-        db_data:
-          driver: local
-    CONTENTS
-
-    message "Build your rails app:"
-    console "docker-compose run web rails new . --force --database=postgresql"
-    console "docker-compose build"
-
-    message "Setup the database:"
-    message "In your editor, open up `config/database.yml` and change it to the following:"
-    source_code :ruby, <<-CONTENTS
-      default: &default
-        adapter: postgresql
-        encoding: unicode
-        username: postgres
-        password:
-        pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-        host: <%= ENV.fetch("DB_HOST") %>
-      development:
-        <<: *default
-        database: test_app_development
-      test:
-        <<: *default
-        database: test_app_test
-      production:
-        <<: *default
-        database: test_app_production
-        password: <%= ENV['APP_DATABASE_PASSWORD'] %>
-    CONTENTS
-    console "docker-compose run web bin/rails db:create"
-    console "docker-compose run web bin/rails db:migrate"
-
-    message "Spin up the rails server:"
-    console "docker-compose up"
-    tip "`docker-compose up` will execute the command, `bin/rails s -p 3000 -b '0.0.0.0'`, in `docker-compose.yml`"
-  end
+  console "cd test_app"
+  console "rails server"
 
   tip "In OS X, you may need to let Ruby accept incoming network connections through your firewall.  Select 'allow' in the pop up."
 
@@ -149,16 +64,10 @@ step "Create a new Rails app" do
   tip "If it doesn't work, ask a TA for help."
   message "* In your browser, go to <http://localhost:3000>"
   img src: "img/successful_rails_install.png", alt: "Screenshot of the browser on localhost 3000 showing the rails intro page"
-  option_half "Without Docker" do
-    message <<-MARKDOWN
-      * Back in the Terminal window where you ran <code>rails server</code>, type **Control-C** (don't type this into the console, but hold the Control and C keys at the same time) to kill(stop) the server. Windows will ask "Terminate batch job (Y/N)?".  Type "Y".
-    MARKDOWN
-  end
-  option_half "With Docker" do
-    message <<-MARKDOWN
-      * Open a new Terminal tab, type **docker-compose down** to stop the server.
-    MARKDOWN
-  end
+  message <<-MARKDOWN
+
+    * Back in the Terminal window where you ran <code>rails server</code>, type **Control-C** (don't type this into the console, but hold the Control and C keys at the same time) to kill(stop) the server. Windows will ask "Terminate batch job (Y/N)?".  Type "Y".
+  MARKDOWN
 
   important "On Windows, sometimes Control-C doesn't work. In that case, look for the key called 'Break' or 'Pause' and press Control-Break, then answer Y at the prompt. If there is no Pause/Break key on your keyboard, you can run `ruby script/rails server` instead of `rails server` which should allow Control-C to stop the server."
 end
@@ -168,29 +77,15 @@ step "Generate a database model" do
     console "cd test_app"
   end
 
-  tip "If you're using Docker, execute the following commands in the web service container" do
-    message "run bash to interact with the directory inside the web service container:"
-    console "docker-compose run web bash"
-  end
-
   console <<-BASH
     rails generate scaffold drink name:string temperature:integer
   BASH
   console <<-BASH
     rails db:migrate
   BASH
-
-  option_half "Without Docker" do
-    console <<-BASH
-      rails server
-    BASH
-  end
-
-  option_half "With Docker" do
-    console <<-BASH
-      docker-compose up
-    BASH
-  end
+  console <<-BASH
+    rails server
+  BASH
 
   message <<-MARKDOWN
     **Note:** the above are three separate commands. Type each line into the terminal separately, not as one single command.
@@ -207,9 +102,7 @@ step "Generate a database model" do
     You should see: ![Screenshot of the drink detail page](img/get_a_sticker_you_should_see.png)
 
     In your terminal, Hold Control and hit C (or on Windows, Control-Break, Y) to stop the rails server.
-    **For Docker**, in a new terminal tab, type **docker-compose down** to stop the server.
   MARKDOWN
 end
 
 next_step "deploy_a_rails_app"
-

--- a/sites/en/installfest/create_a_rails_app_with_docker.step
+++ b/sites/en/installfest/create_a_rails_app_with_docker.step
@@ -1,0 +1,143 @@
+step "Change to your home directory" do
+  insert 'switch_to_home_directory'
+end
+
+step "Create a railsbridge directory" do
+  console "mkdir railsbridge"
+  message "`mkdir` stands for make directory (folder)."
+  message "We've made a folder called `railsbridge`."
+end
+
+step "Change to your new railsbridge directory" do
+  console "cd railsbridge"
+end
+
+step "Create a new Rails app" do
+  console "mkdir test_app"
+  console "cd test_app"
+
+  message "In your editor, create a new file called `Gemfile`"
+  message "Copy the following into `Gemfile`:"
+  source_code :ruby, <<-CONTENTS
+    source "https://rubygems.org"
+    gem "rails", "5.2.0"
+  CONTENTS
+  console "touch Gemfile.lock"
+
+  message "In your editor, create a new file called `Dockerfile`:"
+  message "Copy the following into `Dockerfile`:"
+  source_code :text, <<-CONTENTS
+    FROM ruby:2.5.1-slim
+
+    RUN apt-get update -qq && apt-get install -y build-essential libpq-dev git vim nodejs postgresql-client build-essential
+
+    ENV APP_HOME /test_app
+    RUN mkdir -p $APP_HOME
+    WORKDIR $APP_HOME
+    COPY Gemfile* $APP_HOME/
+    RUN bundle install --binstubs
+    COPY . $APP_HOME
+  CONTENTS
+
+  message "In your editor, create a new file called `docker-compose.yml`:"
+  message "Copy the following into `docker-compose.yml`:"
+  source_code :text, <<-CONTENTS
+    version: '3'
+    services:
+      db:
+        image: postgres:10.3
+        volumes:
+          - db_data:/var/lib/postgresql/data
+      web:
+        build: .
+        environment:
+          DB_HOST: db
+        tty: true
+        stdin_open: true
+        volumes:
+          - .:/test_app
+        command: bin/rails s -p 3000 -b '0.0.0.0'
+        ports:
+          - "3000:3000"
+        depends_on:
+          - db
+    volumes:
+      db_data:
+        driver: local
+  CONTENTS
+
+  message "Build your rails app:"
+  console "docker-compose run web rails new . --force --database=postgresql"
+  console "docker-compose build"
+
+  message "Setup the database:"
+  message "In your editor, open up `config/database.yml` and change it to the following:"
+  source_code :ruby, <<-CONTENTS
+    default: &default
+      adapter: postgresql
+      encoding: unicode
+      username: postgres
+      password:
+      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+      host: <%= ENV.fetch("DB_HOST") %>
+    development:
+      <<: *default
+      database: test_app_development
+    test:
+      <<: *default
+      database: test_app_test
+    production:
+      <<: *default
+      database: test_app_production
+      password: <%= ENV['APP_DATABASE_PASSWORD'] %>
+  CONTENTS
+  console "docker-compose run web bin/rails db:create"
+  console "docker-compose run web bin/rails db:migrate"
+
+  console "docker-compose up"
+  tip "`docker-compose up` will execute the command, `bin/rails s -p 3000 -b '0.0.0.0'`, in `docker-compose.yml`"
+
+  message "In your browser, go to <http://localhost:3000>"
+  img src: "img/successful_rails_install.png", alt: "Screenshot of the browser on localhost 3000 showing the rails intro page"
+
+  message "Open a new terminal tab, and stop the server."
+  console "docker-compose down"
+end
+
+step "Generate a database model" do
+  tip "If your prompt doesn't already show that you are (still) in the test_app folder" do
+    console "cd test_app"
+  end
+
+  message "Run the following in terminal:"
+  console "docker-compose run web bash"
+
+  console <<-BASH
+    rails generate scaffold drink name:string temperature:integer
+  BASH
+
+  console <<-BASH
+    rails db:migrate
+  BASH
+
+  message "Open another tab in terminal to bring the rails server up in Docker with:"
+  console <<-BASH
+    docker-compose up
+  BASH
+
+  message <<-MARKDOWN
+    In the browser, visit <http://localhost:3000/drinks>
+
+    1. Click on "New drink"
+    2. Enter Cappuccino for the name
+    3. Enter 135 for the temperature.
+    4. Click on "Create Drink".
+
+    You should see: ![Screenshot of the drink detail page](img/get_a_sticker_you_should_see.png)
+
+  MARKDOWN
+  message "Open a new terminal tab, and stop the server."
+  console "docker-compose down"
+end
+
+next_step "deploy_a_rails_app"

--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -55,9 +55,9 @@ step "Deploy your app to Heroku" do
   end
 
   step "Prepare your rails app for deploying to Heroku" do
-    message <<-MARKDOWN
-      **SKIP THIS STEP IF YOU'RE USING DOCKER**
-    MARKDOWN
+    tip do
+      message "**WAIT!  If you are using Docker, SKIP this step and proceed to Step 2.3**"
+    end
 
     message <<-MARKDOWN
       Launch your text editor and open the "Gemfile" file located inside of your test_app folder. (On Windows, this should be in `C:\\Sites\\railsbridge\\test_app` and on Linux/OS X, it should be under `~/railsbridge/test_app`.)

--- a/sites/en/installfest/docker.step
+++ b/sites/en/installfest/docker.step
@@ -1,17 +1,17 @@
 step "Install Docker" do
   option "Docker for Mac" do
-    message "Visit [Docker for Mac download page](https://store.docker.com/editions/community/docker-ce-desktop-mac)
+    message "Visit [Docker for Mac download page](https://store.docker.com/editions/community/docker-ce-desktop-mac)"
     message "Download and install the **Stable** verion"
   end
 
   option "Docker for Windows" do
-    message "Visit [Docker for Windows download page](https://store.docker.com/editions/community/docker-ce-desktop-windows)
-    message "Download and install the **Stable** verion"
+    message "Visit [Docker for Windows download page](https://store.docker.com/editions/community/docker-ce-desktop-windows)"
+    message "Download and install the **Stable** version"
   end
 
   option "Docker for Ubuntu" do
-    message "Visit [Docker for Ubuntu download page](https://store.docker.com/editions/community/docker-ce-server-ubuntu)
-    message "Download and install the **Stable** verion"
+    message "Visit [Docker for Ubuntu download page](https://store.docker.com/editions/community/docker-ce-server-ubuntu)"
+    message "Download and install the **Stable** version"
   end
 
   option "Docker for other platforms" do


### PR DESCRIPTION
1.  Fix spelling and syntax errors on sites/en/installfest/docker.step
2.  The Create a Rails App section diverges dramatically for Docker and non-Docker users, so I split the Docker Create a Rails App docs into their own page.
3. Small change to clarify instructions for Docker users and make them consistent:  sites/en/installfest/deploy_a_rails_app.step